### PR TITLE
Fixes #39

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const fileSearch = require('./lib/file_search');
 const parseOptions = require('./lib/parse_options');
 const silentRequire = require('./lib/silent_require');
 const buildConfigName = require('./lib/build_config_name');
+const rechoir = require('rechoir');
 
 function Liftoff (opts) {
   EE.call(this);
@@ -22,7 +23,8 @@ util.inherits(Liftoff, EE);
 
 Liftoff.prototype.requireLocal = function (module, basedir) {
   try {
-    var result = require(resolve.sync(module, {basedir: basedir}));
+    rechoir.registerFor(module, basedir);
+    var result = require(resolve.sync(module, {basedir:basedir}));
     this.emit('require', module, result);
     return result;
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "findup-sync": "~0.2.0",
     "flagged-respawn": "~0.3.0",
     "minimist": "~1.1.0",
-    "resolve": "~1.1.0"
+    "resolve": "~1.1.0",
+    "rechoir": ">=0.3.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -34,35 +34,27 @@ describe('Liftoff', function () {
   describe('buildEnvironment', function () {
 
     it('should attempt pre-loading local modules if they are requested', function () {
-      var name, mod;
       app.on('require', function (moduleName, module) {
-        name = moduleName;
-        mod = module;
+        expect(moduleName).to.equal('coffee-script/register');
+        expect(module).to.equal(require('coffee-script/register'));
       });
       var env = app.buildEnvironment({require:['coffee-script/register']});
-      expect(name).to.equal('coffee-script/register');
-      expect(mod).to.equal(require('coffee-script/register'));
       expect(env.require).to.deep.equal(['coffee-script/register']);
     });
 
     it('should attempt pre-loading local modules based on extension option', function () {
-      var name, mod;
       app.on('require', function (moduleName, module) {
-        name = moduleName;
-        mod = module;
+        expect(moduleName).to.equal('coffee-script/register');
+        expect(module).to.equal(require('coffee-script/register'));
       });
       var env = app.buildEnvironment({
         configPath: 'test/fixtures/coffee/mochafile.coffee'
       });
-      expect(name).to.equal('coffee-script/register');
-      expect(mod).to.equal(require('coffee-script/register'));
       expect(env.require).to.deep.equal(['coffee-script/register']);
       // testing compound extension
       env = app.buildEnvironment({
         configPath: 'test/fixtures/coffee/mochafile.coffee.md'
       });
-      expect(name).to.equal('coffee-script/register');
-      expect(mod).to.equal(require('coffee-script/register'));
       expect(env.require).to.deep.equal(['coffee-script/register']);
     });
 
@@ -161,7 +153,6 @@ describe('Liftoff', function () {
     it('should emit a respawn event if a respawn is required', function (done) {
       exec('node test/fixtures/v8flags.js', function (err, stdout) {
         expect(stdout).to.be.empty;
-        done();
         exec('node test/fixtures/v8flags_function.js --lazy', function (err, stdout) {
           expect(stdout).to.equal('saw respawn\n');
           done();


### PR DESCRIPTION
- fixes #39: integrate node-rechoir

Also fixes issues in the existing test cases that would cause failures due to the asynchronous nature of the tests. Also fixes issues where done() was being called twice.
