### PR TITLE
Support loading from NODE_PATH, fixes tkellen/node-liftoff#28

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,9 @@ Liftoff.prototype.buildEnvironment = function (opts) {
   // locate local module and package next to config or explicitly provided cwd
   var modulePath, modulePackage;
   try {
-    modulePath = resolve.sync(this.moduleName, {basedir: configBase || cwd, paths: (process.env.NODE_PATH ? process.env.NODE_PATH.split(':') : [])});
+    var delim = (process.platform === 'win32' ? ';' : ':'),
+        paths = (process.env.NODE_PATH ? process.env.NODE_PATH.split(delim) : []);
+    modulePath = resolve.sync(this.moduleName, {basedir: configBase || cwd, paths: paths});
     modulePackage = silentRequire(fileSearch('package.json', [modulePath]));
   } catch (e) {}
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ Liftoff.prototype.buildEnvironment = function (opts) {
   // locate local module and package next to config or explicitly provided cwd
   var modulePath, modulePackage;
   try {
-    modulePath = resolve.sync(this.moduleName, {basedir: configBase || cwd});
+    modulePath = resolve.sync(this.moduleName, {basedir: configBase || cwd, paths: (process.env.NODE_PATH ? process.env.NODE_PATH.split(':') : [])});
     modulePackage = silentRequire(fileSearch('package.json', [modulePath]));
   } catch (e) {}
 

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,17 @@ describe('Liftoff', function () {
       var spy = sinon.spy(resolve, 'sync');
       test.buildEnvironment({cwd:cwd});
       expect(spy.calledWith('chai', {basedir:path.join(process.cwd(),cwd),paths:[]})).to.be.true;
+      spy.restore();
+    });
+
+    it('should locate global module using NODE_PATH if defined', function () {
+      var test = new Liftoff({name:'dummy'});
+      var cwd = 'explicit/cwd';
+      var spy = sinon.spy(resolve, 'sync');
+      process.env.NODE_PATH = path.join(process.cwd(),cwd)
+      test.buildEnvironment();
+      expect(spy.calledWith('dummy', {basedir:process.cwd(),paths:[path.join(process.cwd(),cwd)]})).to.be.true;
+      spy.restore();
     });
 
     it('if cwd is explicitly provided, don\'t use search_paths', function () {


### PR DESCRIPTION
This will pass NODE_PATH to resolve.sync when looking for the module to require, or empty array if undefined (default for most people) which behaves the same.